### PR TITLE
[完成] 前台登入/登出/註冊路由，passport權限設定

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const app = express();
-
+const db = require("./models");
 const helpers = require("./_helpers");
 const exphbs = require("express-handlebars");
 const port = process.env.PORT || 3000;

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const port = process.env.PORT || 3000;
 const bodyParser = require("body-parser");
 const session = require("express-session");
 const flash = require("connect-flash");
-// const passport = require('./config/passport')
+const passport = require("./config/passport");
 const methodOverride = require("method-override");
 
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -21,8 +21,8 @@ app.use(
 );
 app.use(flash());
 
-// app.use(passport.initialize())
-// app.use(passport.session())
+app.use(passport.initialize());
+app.use(passport.session());
 
 app.use(methodOverride("_method"));
 
@@ -43,4 +43,4 @@ app.use((req, res, next) => {
 
 app.listen(port, () => console.log(`Express app listening on port ${port}!`));
 
-require("./routes")(app);
+require("./routes")(app, passport);

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,0 +1,47 @@
+const passport = require("passport");
+const LocalStrategy = require("passport-local");
+const bcrypt = require("bcrypt-nodejs");
+const db = require("../models");
+const User = db.User;
+
+// setup passport strategy
+passport.use(
+  new LocalStrategy(
+    // customize user field
+    {
+      usernameField: "email",
+      passwordField: "password",
+      passReqToCallback: true
+    },
+    // authenticate user
+    (req, username, password, cb) => {
+      User.findOne({ where: { email: username } }).then(user => {
+        if (!user)
+          return cb(
+            null,
+            false,
+            req.flash("error_messages", "帳號或密碼輸入錯誤！")
+          );
+        if (!bcrypt.compareSync(password, user.password))
+          return cb(
+            null,
+            false,
+            req.flash("error_messages", "帳號或密碼輸入錯誤！")
+          );
+        return cb(null, user);
+      });
+    }
+  )
+);
+
+// serialize and deserialize user
+passport.serializeUser((user, cb) => {
+  cb(null, user.id);
+});
+passport.deserializeUser((id, cb) => {
+  User.findByPk(id).then(user => {
+    return cb(null, user);
+  });
+});
+
+module.exports = passport;

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,21 @@
+const bcrypt = require("bcrypt-nodejs");
+const db = require("../models");
+const User = db.User;
+
+const userController = {
+  signUpPage: (req, res) => {
+    return res.render("signup");
+  },
+
+  signUp: (req, res) => {
+    User.create({
+      name: req.body.name,
+      email: req.body.email,
+      password: bcrypt.hashSync(req.body.password, bcrypt.genSaltSync(10), null)
+    }).then(user => {
+      return res.redirect("/signin");
+    });
+  }
+};
+
+module.exports = userController;

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -8,13 +8,32 @@ const userController = {
   },
 
   signUp: (req, res) => {
-    User.create({
-      name: req.body.name,
-      email: req.body.email,
-      password: bcrypt.hashSync(req.body.password, bcrypt.genSaltSync(10), null)
-    }).then(user => {
-      return res.redirect("/signin");
-    });
+    // confirm password
+    if (req.body.passwordCheck !== req.body.password) {
+      req.flash("error_messages", "兩次密碼輸入不同！");
+      return res.redirect("/signup");
+    } else {
+      // confirm unique user
+      User.findOne({ where: { email: req.body.email } }).then(user => {
+        if (user) {
+          req.flash("error_messages", "信箱重複！");
+          return res.redirect("/signup");
+        } else {
+          User.create({
+            name: req.body.name,
+            email: req.body.email,
+            password: bcrypt.hashSync(
+              req.body.password,
+              bcrypt.genSaltSync(10),
+              null
+            )
+          }).then(user => {
+            req.flash("success_messages", "成功註冊帳號！");
+            return res.redirect("/signin");
+          });
+        }
+      });
+    }
   }
 };
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -34,6 +34,21 @@ const userController = {
         }
       });
     }
+  },
+
+  signInPage: (req, res) => {
+    return res.render("signin");
+  },
+
+  signIn: (req, res) => {
+    req.flash("success_messages", "成功登入！");
+    res.redirect("/tweets");
+  },
+
+  logout: (req, res) => {
+    req.flash("success_messages", "登出成功！");
+    req.logout();
+    res.redirect("/signin");
   }
 };
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,8 +1,13 @@
 const tweetController = require("../controllers/tweetController");
+const userController = require("../controllers/userController");
 module.exports = app => {
   //如果使用者訪問首頁，就導向 /tweets 的頁面
   app.get("/", (req, res) => res.redirect("/tweets"));
 
   //在 /tweets 底下則交給 restController.getTweets 來處理
   app.get("/tweets", tweetController.getTweets);
+
+  // signup
+  app.get("/signup", userController.signUpPage);
+  app.post("/signup", userController.signUp);
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,11 +1,29 @@
 const tweetController = require("../controllers/tweetController");
 const userController = require("../controllers/userController");
+const adminController = require("../controllers/adminController");
 module.exports = (app, passport) => {
+  // 驗證使用者權限
+  const authenticated = (req, res, next) => {
+    if (req.isAuthenticated()) {
+      return next();
+    }
+    res.redirect("/signin");
+  };
+  const authenticatedAdmin = (req, res, next) => {
+    if (req.isAuthenticated()) {
+      if (req.user.role === "admin") {
+        return next();
+      }
+      return res.redirect("/");
+    }
+    res.redirect("/signin");
+  };
+
   //如果使用者訪問首頁，就導向 /tweets 的頁面
-  app.get("/", (req, res) => res.redirect("/tweets"));
+  app.get("/", authenticated, (req, res) => res.redirect("/tweets"));
 
   //在 /tweets 底下則交給 restController.getTweets 來處理
-  app.get("/tweets", tweetController.getTweets);
+  app.get("/tweets", authenticated, tweetController.getTweets);
 
   // signup
   app.get("/signup", userController.signUpPage);
@@ -22,4 +40,10 @@ module.exports = (app, passport) => {
     userController.signIn
   );
   app.get("/logout", userController.logout);
+
+  // adminController
+  // app.get("/admin", authenticatedAdmin, (req, res) =>
+  //   res.redirect("/admin/tweets")
+  // );
+  // app.get("/admin/tweets", authenticatedAdmin, adminController.getTweets);
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,6 @@
 const tweetController = require("../controllers/tweetController");
 const userController = require("../controllers/userController");
-module.exports = app => {
+module.exports = (app, passport) => {
   //如果使用者訪問首頁，就導向 /tweets 的頁面
   app.get("/", (req, res) => res.redirect("/tweets"));
 
@@ -10,4 +10,16 @@ module.exports = app => {
   // signup
   app.get("/signup", userController.signUpPage);
   app.post("/signup", userController.signUp);
+
+  // signin
+  app.get("/signin", userController.signInPage);
+  app.post(
+    "/signin",
+    passport.authenticate("local", {
+      failureRedirect: "/signin",
+      failureFlash: true
+    }),
+    userController.signIn
+  );
+  app.get("/logout", userController.logout);
 };

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -21,6 +21,16 @@
     <div class="navbar-collapse offcanvas-collapse" id="navbarsExampleDefault">
       <ul class="navbar-nav mr-auto">
       </ul>
+      <div>
+        {{#if user.isAdmin}}
+        <a href="/admin" style="color: white;margin-right: 10px;">Admin 後台</a>
+        {{/if}}
+        {{#if user}}
+        <span style="color: white;margin-right: 10px;">Hi, {{user.name}}</span>
+        <a href="/users/{{user.id}}" style="color: white;margin-right: 10px;">Profile</a>
+        <a href="/logout"><button class="btn btn-outline-success my-2 my-sm-0">LogOut</button></a>
+        {{/if}}
+      </div>
     </div>
   </nav>
   <br />

--- a/views/signin.handlebars
+++ b/views/signin.handlebars
@@ -1,0 +1,19 @@
+<form class="form-signin" action="/signin" method="POST" style="width: 100%;">
+  <div class="text-center mb-4">
+    <h1 class="h3 mb-3 font-weight-normal">Sign In</h1>
+  </div>
+  <div class="form-label-group">
+    <label for="inputEmail">Email</label>
+    <input type="text" name="email" class="form-control" placeholder="Email" required autofocus>
+  </div>
+  <div class="form-label-group">
+    <label for="inputPassword">Password</label>
+    <input type="password" name="password" class="form-control" placeholder="Password" required>
+  </div>
+  <br />
+  <button class="btn btn-lg btn-primary btn-block" type="submit">Submit</button>
+  <div class="text-center mb-4">
+    <p><a href="/signup">Sign Up</a></p>
+  </div>
+  <p class="mt-5 mb-3 text-muted text-center">© 2017-2018</p>
+</form>

--- a/views/signup.handlebars
+++ b/views/signup.handlebars
@@ -1,0 +1,27 @@
+<form class="form-signin" action="/signup" method="POST" style="width: 100%;">
+  <div class="text-center mb-4">
+    <h1 class="h3 mb-3 font-weight-normal">Sign Up</h1>
+  </div>
+  <div class="form-label-group">
+    <label for="inputName">Name</label>
+    <input type="text" name="name" class="form-control" placeholder="Name" required autofocus>
+  </div>
+  <div class="form-label-group">
+    <label for="inputEmail">Email</label>
+    <input type="text" name="email" class="form-control" placeholder="Email" required autofocus>
+  </div>
+  <div class="form-label-group">
+    <label for="inputPassword">Password</label>
+    <input type="password" name="password" class="form-control" placeholder="Password" required>
+  </div>
+  <div class="form-label-group">
+    <label for="inputPasswordCheck">Password Check</label>
+    <input type="password" name="passwordCheck" class="form-control" placeholder="Password Check" required>
+  </div>
+  <br />
+  <button class="btn btn-lg btn-primary btn-block" type="submit">Submit</button>
+  <div class="text-center mb-4">
+    <p><a href="/signin">Sign In</a></p>
+  </div>
+  <p class="mt-5 mb-3 text-muted text-center">© 2017-2018</p>
+</form>

--- a/views/tweets.handlebars
+++ b/views/tweets.handlebars
@@ -1,2 +1,1 @@
 <h3>this is page for /tweets</h3>
-<h3>Test</h3>

--- a/views/tweets.handlebars
+++ b/views/tweets.handlebars
@@ -1,1 +1,2 @@
 <h3>this is page for /tweets</h3>
+<h3>Test</h3>


### PR DESCRIPTION
[ 前台登入/登出/註冊路由 ]
已完成下列路由
GET /signin
POST /signin
GET /signup
POST /signup
GET /logout

測試方式
- 註冊
   - 驗證：密碼不一致 / name未輸入 / 信箱重複註冊
- 登入
   - 驗證：信箱不存在 / 密碼錯誤
- 登出
    - 按navbar的logout可成功登出跳回signInPage
- 各種動作都應有提示訊息

[ passport權限設定 ]
＊已設定用user model的role欄位來區分一般使用者與管理者的權限差別
＊role欄位的default未設定，目前是用 role === "admin" 認定是管理者，但一般使用者要用什麼來代表還需要討論 ( 或許用role === "normal" )

測試方式
- 一般使用者
    - GET /tweets 正常顯示tweets畫面
    - GET /admin 跳回tweets畫面

- 管理者
    - GET /tweets 正常顯示tweets畫面
    - GET /admin 正常顯示admin/tweets畫面




